### PR TITLE
feat: add HTTP transport support and mcpServers format

### DIFF
--- a/example-github-mcp.json
+++ b/example-github-mcp.json
@@ -1,9 +1,0 @@
-{
-  "name": "github",
-  "description": "GitHub API access via MCP",
-  "command": "npx",
-  "args": ["-y", "@modelcontextprotocol/server-github"],
-  "env": {
-    "GITHUB_TOKEN": "your-github-token-here"
-  }
-}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,40 @@
+{
+  "mcpServers": {
+    "trello": {
+      "description": "Trello MCP server",
+      "command": "bun",
+      "args": [
+        "run",
+        "/path/to/mcp-server-trello/src/index.ts"
+      ],
+      "env": {
+        "TRELLO_API_KEY": "your-api-key",
+        "TRELLO_TOKEN": "your-token"
+      }
+    },
+    "aws-knowledge": {
+      "description": "AWS Knowledge MCP server",
+      "type": "http",
+      "url": "https://knowledge-mcp.global.api.aws"
+    },
+    "scraperapi": {
+      "description": "ScraperAPI MCP server",
+      "command": "uvx",
+      "args": [
+        "scraperapi-mcp-server"
+      ],
+      "env": {
+        "API_KEY": "your-api-key"
+      }
+    },
+    "datadog": {
+      "description": "Datadog MCP server",
+      "type": "http",
+      "url": "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp?toolsets=core",
+      "headers": {
+        "DD_API_KEY": "your-api-key",
+        "DD_APPLICATION_KEY": "your-app-key"
+      }
+    }
+  }
+}

--- a/skills/aws-knowledge/SKILL.md
+++ b/skills/aws-knowledge/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: aws-knowledge
+description: Dynamic access to aws-knowledge MCP server (1 tools)
+version: 1.0.0
+---
+
+# aws-knowledge Skill
+
+This skill provides dynamic access to the aws-knowledge MCP server without loading all tool definitions into context.
+
+## Transport Type
+
+This skill connects via: **HTTP (https://knowledge-mcp.global.api.aws)**
+
+## Context Efficiency
+
+Traditional MCP approach:
+- All 1 tools loaded at startup
+- Estimated context: 500 tokens
+
+This skill approach:
+- Metadata only: ~100 tokens
+- Full instructions (when used): ~5k tokens
+- Tool execution: 0 tokens (runs externally)
+
+## How This Works
+
+Instead of loading all MCP tool definitions upfront, this skill:
+1. Tells you what tools are available (just names and brief descriptions)
+2. You decide which tool to call based on the user's request
+3. Generate a JSON command to invoke the tool
+4. The executor handles the actual MCP communication
+
+## Available Tools
+
+- `example_tool`: An example tool from the MCP server
+
+## Usage Pattern
+
+When the user's request matches this skill's capabilities:
+
+**Step 1: Identify the right tool** from the list above
+
+**Step 2: Generate a tool call** in this JSON format:
+
+```json
+{
+  "tool": "tool_name",
+  "arguments": {
+    "param1": "value1",
+    "param2": "value2"
+  }
+}
+```
+
+**Step 3: Execute via bash:**
+
+```bash
+cd $SKILL_DIR
+python executor.py --call 'YOUR_JSON_HERE'
+```
+
+IMPORTANT: Replace $SKILL_DIR with the actual discovered path of this skill directory.
+
+## Getting Tool Details
+
+If you need detailed information about a specific tool's parameters:
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe tool_name
+```
+
+This loads ONLY that tool's schema, not all tools.
+
+## Examples
+
+### Example 1: Simple tool call
+
+User: "Use aws-knowledge to do X"
+
+Your workflow:
+1. Identify tool: `example_tool`
+2. Generate call JSON
+3. Execute:
+
+```bash
+cd $SKILL_DIR
+python executor.py --call '{"tool": "example_tool", "arguments": {"param1": "value"}}'
+```
+
+### Example 2: Get tool details first
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe example_tool
+```
+
+Returns the full schema, then you can generate the appropriate call.
+
+## Error Handling
+
+If the executor returns an error:
+- Check the tool name is correct
+- Verify required arguments are provided
+- Ensure the MCP server is accessible
+
+## Performance Notes
+
+Context usage comparison for this skill:
+
+| Scenario | MCP (preload) | Skill (dynamic) |
+|----------|---------------|-----------------|
+| Idle | 500 tokens | 100 tokens |
+| Active | 500 tokens | 5k tokens |
+| Executing | 500 tokens | 0 tokens |
+
+Savings: ~-900% reduction in typical usage
+
+---
+
+*This skill was auto-generated from an MCP server configuration.*
+*Generator: mcp_to_skill.py*

--- a/skills/aws-knowledge/executor.py
+++ b/skills/aws-knowledge/executor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+MCP Skill Executor
+==================
+Handles dynamic communication with the MCP server.
+"""
+
+import json
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+# Check if mcp package is available
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+    print("Warning: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+
+
+@asynccontextmanager
+async def mcp_connection(config):
+    """Context manager for MCP server connection."""
+    transport_type = config.get("type", "stdio")
+
+    if transport_type == "http":
+        url = config["url"]
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+    else:
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=config.get("env")
+        )
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+
+async def list_tools(session):
+    """Get list of available tools."""
+    response = await session.list_tools()
+    return [{"name": t.name, "description": t.description} for t in response.tools]
+
+
+async def describe_tool(session, tool_name: str):
+    """Get detailed schema for a specific tool."""
+    response = await session.list_tools()
+    for tool in response.tools:
+        if tool.name == tool_name:
+            return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+    return None
+
+
+async def call_tool(session, tool_name: str, arguments: dict):
+    """Execute a tool call."""
+    response = await session.call_tool(tool_name, arguments)
+    return response.content
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MCP Skill Executor")
+    parser.add_argument("--call", help="JSON tool call to execute")
+    parser.add_argument("--describe", help="Get tool schema")
+    parser.add_argument("--list", action="store_true", help="List all tools")
+
+    args = parser.parse_args()
+
+    config_path = Path(__file__).parent / "mcp-config.json"
+    if not config_path.exists():
+        print(f"Error: Config not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    if not HAS_MCP:
+        print("Error: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        async with mcp_connection(config) as session:
+            if args.list:
+                tools = await list_tools(session)
+                print(json.dumps(tools, indent=2))
+
+            elif args.describe:
+                schema = await describe_tool(session, args.describe)
+                if schema:
+                    print(json.dumps(schema, indent=2))
+                else:
+                    print(f"Tool not found: {args.describe}", file=sys.stderr)
+                    sys.exit(1)
+
+            elif args.call:
+                call_data = json.loads(args.call)
+                result = await call_tool(session, call_data["tool"], call_data.get("arguments", {}))
+                if isinstance(result, list):
+                    for item in result:
+                        print(item.text if hasattr(item, 'text') else json.dumps(item, indent=2))
+                else:
+                    print(json.dumps(result, indent=2))
+            else:
+                parser.print_help()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/aws-knowledge/mcp-config.json
+++ b/skills/aws-knowledge/mcp-config.json
@@ -1,0 +1,6 @@
+{
+  "description": "AWS Knowledge MCP server",
+  "type": "http",
+  "url": "https://knowledge-mcp.global.api.aws",
+  "name": "aws-knowledge"
+}

--- a/skills/aws-knowledge/package.json
+++ b/skills/aws-knowledge/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "skill-aws-knowledge",
+  "version": "1.0.0",
+  "description": "Claude Skill wrapper for aws-knowledge MCP server",
+  "scripts": {
+    "setup": "pip install mcp"
+  }
+}

--- a/skills/datadog/SKILL.md
+++ b/skills/datadog/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: datadog
+description: Dynamic access to datadog MCP server (1 tools)
+version: 1.0.0
+---
+
+# datadog Skill
+
+This skill provides dynamic access to the datadog MCP server without loading all tool definitions into context.
+
+## Transport Type
+
+This skill connects via: **HTTP (https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp?toolsets=core)**
+
+## Context Efficiency
+
+Traditional MCP approach:
+- All 1 tools loaded at startup
+- Estimated context: 500 tokens
+
+This skill approach:
+- Metadata only: ~100 tokens
+- Full instructions (when used): ~5k tokens
+- Tool execution: 0 tokens (runs externally)
+
+## How This Works
+
+Instead of loading all MCP tool definitions upfront, this skill:
+1. Tells you what tools are available (just names and brief descriptions)
+2. You decide which tool to call based on the user's request
+3. Generate a JSON command to invoke the tool
+4. The executor handles the actual MCP communication
+
+## Available Tools
+
+- `example_tool`: An example tool from the MCP server
+
+## Usage Pattern
+
+When the user's request matches this skill's capabilities:
+
+**Step 1: Identify the right tool** from the list above
+
+**Step 2: Generate a tool call** in this JSON format:
+
+```json
+{
+  "tool": "tool_name",
+  "arguments": {
+    "param1": "value1",
+    "param2": "value2"
+  }
+}
+```
+
+**Step 3: Execute via bash:**
+
+```bash
+cd $SKILL_DIR
+python executor.py --call 'YOUR_JSON_HERE'
+```
+
+IMPORTANT: Replace $SKILL_DIR with the actual discovered path of this skill directory.
+
+## Getting Tool Details
+
+If you need detailed information about a specific tool's parameters:
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe tool_name
+```
+
+This loads ONLY that tool's schema, not all tools.
+
+## Examples
+
+### Example 1: Simple tool call
+
+User: "Use datadog to do X"
+
+Your workflow:
+1. Identify tool: `example_tool`
+2. Generate call JSON
+3. Execute:
+
+```bash
+cd $SKILL_DIR
+python executor.py --call '{"tool": "example_tool", "arguments": {"param1": "value"}}'
+```
+
+### Example 2: Get tool details first
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe example_tool
+```
+
+Returns the full schema, then you can generate the appropriate call.
+
+## Error Handling
+
+If the executor returns an error:
+- Check the tool name is correct
+- Verify required arguments are provided
+- Ensure the MCP server is accessible
+
+## Performance Notes
+
+Context usage comparison for this skill:
+
+| Scenario | MCP (preload) | Skill (dynamic) |
+|----------|---------------|-----------------|
+| Idle | 500 tokens | 100 tokens |
+| Active | 500 tokens | 5k tokens |
+| Executing | 500 tokens | 0 tokens |
+
+Savings: ~-900% reduction in typical usage
+
+---
+
+*This skill was auto-generated from an MCP server configuration.*
+*Generator: mcp_to_skill.py*

--- a/skills/datadog/executor.py
+++ b/skills/datadog/executor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+MCP Skill Executor
+==================
+Handles dynamic communication with the MCP server.
+"""
+
+import json
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+# Check if mcp package is available
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+    print("Warning: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+
+
+@asynccontextmanager
+async def mcp_connection(config):
+    """Context manager for MCP server connection."""
+    transport_type = config.get("type", "stdio")
+
+    if transport_type == "http":
+        url = config["url"]
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+    else:
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=config.get("env")
+        )
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+
+async def list_tools(session):
+    """Get list of available tools."""
+    response = await session.list_tools()
+    return [{"name": t.name, "description": t.description} for t in response.tools]
+
+
+async def describe_tool(session, tool_name: str):
+    """Get detailed schema for a specific tool."""
+    response = await session.list_tools()
+    for tool in response.tools:
+        if tool.name == tool_name:
+            return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+    return None
+
+
+async def call_tool(session, tool_name: str, arguments: dict):
+    """Execute a tool call."""
+    response = await session.call_tool(tool_name, arguments)
+    return response.content
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MCP Skill Executor")
+    parser.add_argument("--call", help="JSON tool call to execute")
+    parser.add_argument("--describe", help="Get tool schema")
+    parser.add_argument("--list", action="store_true", help="List all tools")
+
+    args = parser.parse_args()
+
+    config_path = Path(__file__).parent / "mcp-config.json"
+    if not config_path.exists():
+        print(f"Error: Config not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    if not HAS_MCP:
+        print("Error: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        async with mcp_connection(config) as session:
+            if args.list:
+                tools = await list_tools(session)
+                print(json.dumps(tools, indent=2))
+
+            elif args.describe:
+                schema = await describe_tool(session, args.describe)
+                if schema:
+                    print(json.dumps(schema, indent=2))
+                else:
+                    print(f"Tool not found: {args.describe}", file=sys.stderr)
+                    sys.exit(1)
+
+            elif args.call:
+                call_data = json.loads(args.call)
+                result = await call_tool(session, call_data["tool"], call_data.get("arguments", {}))
+                if isinstance(result, list):
+                    for item in result:
+                        print(item.text if hasattr(item, 'text') else json.dumps(item, indent=2))
+                else:
+                    print(json.dumps(result, indent=2))
+            else:
+                parser.print_help()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/datadog/mcp-config.json
+++ b/skills/datadog/mcp-config.json
@@ -1,0 +1,10 @@
+{
+  "description": "Datadog MCP server",
+  "type": "http",
+  "url": "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp?toolsets=core",
+  "headers": {
+    "DD_API_KEY": "your-api-key",
+    "DD_APPLICATION_KEY": "your-app-key"
+  },
+  "name": "datadog"
+}

--- a/skills/datadog/package.json
+++ b/skills/datadog/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "skill-datadog",
+  "version": "1.0.0",
+  "description": "Claude Skill wrapper for datadog MCP server",
+  "scripts": {
+    "setup": "pip install mcp"
+  }
+}

--- a/skills/scraperapi/SKILL.md
+++ b/skills/scraperapi/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: scraperapi
+description: Dynamic access to scraperapi MCP server (1 tools)
+version: 1.0.0
+---
+
+# scraperapi Skill
+
+This skill provides dynamic access to the scraperapi MCP server without loading all tool definitions into context.
+
+## Transport Type
+
+This skill connects via: **stdio (local process)**
+
+## Context Efficiency
+
+Traditional MCP approach:
+- All 1 tools loaded at startup
+- Estimated context: 500 tokens
+
+This skill approach:
+- Metadata only: ~100 tokens
+- Full instructions (when used): ~5k tokens
+- Tool execution: 0 tokens (runs externally)
+
+## How This Works
+
+Instead of loading all MCP tool definitions upfront, this skill:
+1. Tells you what tools are available (just names and brief descriptions)
+2. You decide which tool to call based on the user's request
+3. Generate a JSON command to invoke the tool
+4. The executor handles the actual MCP communication
+
+## Available Tools
+
+- `example_tool`: An example tool from the MCP server
+
+## Usage Pattern
+
+When the user's request matches this skill's capabilities:
+
+**Step 1: Identify the right tool** from the list above
+
+**Step 2: Generate a tool call** in this JSON format:
+
+```json
+{
+  "tool": "tool_name",
+  "arguments": {
+    "param1": "value1",
+    "param2": "value2"
+  }
+}
+```
+
+**Step 3: Execute via bash:**
+
+```bash
+cd $SKILL_DIR
+python executor.py --call 'YOUR_JSON_HERE'
+```
+
+IMPORTANT: Replace $SKILL_DIR with the actual discovered path of this skill directory.
+
+## Getting Tool Details
+
+If you need detailed information about a specific tool's parameters:
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe tool_name
+```
+
+This loads ONLY that tool's schema, not all tools.
+
+## Examples
+
+### Example 1: Simple tool call
+
+User: "Use scraperapi to do X"
+
+Your workflow:
+1. Identify tool: `example_tool`
+2. Generate call JSON
+3. Execute:
+
+```bash
+cd $SKILL_DIR
+python executor.py --call '{"tool": "example_tool", "arguments": {"param1": "value"}}'
+```
+
+### Example 2: Get tool details first
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe example_tool
+```
+
+Returns the full schema, then you can generate the appropriate call.
+
+## Error Handling
+
+If the executor returns an error:
+- Check the tool name is correct
+- Verify required arguments are provided
+- Ensure the MCP server is accessible
+
+## Performance Notes
+
+Context usage comparison for this skill:
+
+| Scenario | MCP (preload) | Skill (dynamic) |
+|----------|---------------|-----------------|
+| Idle | 500 tokens | 100 tokens |
+| Active | 500 tokens | 5k tokens |
+| Executing | 500 tokens | 0 tokens |
+
+Savings: ~-900% reduction in typical usage
+
+---
+
+*This skill was auto-generated from an MCP server configuration.*
+*Generator: mcp_to_skill.py*

--- a/skills/scraperapi/executor.py
+++ b/skills/scraperapi/executor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+MCP Skill Executor
+==================
+Handles dynamic communication with the MCP server.
+"""
+
+import json
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+# Check if mcp package is available
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+    print("Warning: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+
+
+@asynccontextmanager
+async def mcp_connection(config):
+    """Context manager for MCP server connection."""
+    transport_type = config.get("type", "stdio")
+
+    if transport_type == "http":
+        url = config["url"]
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+    else:
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=config.get("env")
+        )
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+
+async def list_tools(session):
+    """Get list of available tools."""
+    response = await session.list_tools()
+    return [{"name": t.name, "description": t.description} for t in response.tools]
+
+
+async def describe_tool(session, tool_name: str):
+    """Get detailed schema for a specific tool."""
+    response = await session.list_tools()
+    for tool in response.tools:
+        if tool.name == tool_name:
+            return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+    return None
+
+
+async def call_tool(session, tool_name: str, arguments: dict):
+    """Execute a tool call."""
+    response = await session.call_tool(tool_name, arguments)
+    return response.content
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MCP Skill Executor")
+    parser.add_argument("--call", help="JSON tool call to execute")
+    parser.add_argument("--describe", help="Get tool schema")
+    parser.add_argument("--list", action="store_true", help="List all tools")
+
+    args = parser.parse_args()
+
+    config_path = Path(__file__).parent / "mcp-config.json"
+    if not config_path.exists():
+        print(f"Error: Config not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    if not HAS_MCP:
+        print("Error: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        async with mcp_connection(config) as session:
+            if args.list:
+                tools = await list_tools(session)
+                print(json.dumps(tools, indent=2))
+
+            elif args.describe:
+                schema = await describe_tool(session, args.describe)
+                if schema:
+                    print(json.dumps(schema, indent=2))
+                else:
+                    print(f"Tool not found: {args.describe}", file=sys.stderr)
+                    sys.exit(1)
+
+            elif args.call:
+                call_data = json.loads(args.call)
+                result = await call_tool(session, call_data["tool"], call_data.get("arguments", {}))
+                if isinstance(result, list):
+                    for item in result:
+                        print(item.text if hasattr(item, 'text') else json.dumps(item, indent=2))
+                else:
+                    print(json.dumps(result, indent=2))
+            else:
+                parser.print_help()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/scraperapi/mcp-config.json
+++ b/skills/scraperapi/mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "description": "ScraperAPI MCP server",
+  "command": "uvx",
+  "args": [
+    "scraperapi-mcp-server"
+  ],
+  "env": {
+    "API_KEY": "your-api-key"
+  },
+  "name": "scraperapi"
+}

--- a/skills/scraperapi/package.json
+++ b/skills/scraperapi/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "skill-scraperapi",
+  "version": "1.0.0",
+  "description": "Claude Skill wrapper for scraperapi MCP server",
+  "scripts": {
+    "setup": "pip install mcp"
+  }
+}

--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: trello
+description: Dynamic access to trello MCP server (1 tools)
+version: 1.0.0
+---
+
+# trello Skill
+
+This skill provides dynamic access to the trello MCP server without loading all tool definitions into context.
+
+## Transport Type
+
+This skill connects via: **stdio (local process)**
+
+## Context Efficiency
+
+Traditional MCP approach:
+- All 1 tools loaded at startup
+- Estimated context: 500 tokens
+
+This skill approach:
+- Metadata only: ~100 tokens
+- Full instructions (when used): ~5k tokens
+- Tool execution: 0 tokens (runs externally)
+
+## How This Works
+
+Instead of loading all MCP tool definitions upfront, this skill:
+1. Tells you what tools are available (just names and brief descriptions)
+2. You decide which tool to call based on the user's request
+3. Generate a JSON command to invoke the tool
+4. The executor handles the actual MCP communication
+
+## Available Tools
+
+- `example_tool`: An example tool from the MCP server
+
+## Usage Pattern
+
+When the user's request matches this skill's capabilities:
+
+**Step 1: Identify the right tool** from the list above
+
+**Step 2: Generate a tool call** in this JSON format:
+
+```json
+{
+  "tool": "tool_name",
+  "arguments": {
+    "param1": "value1",
+    "param2": "value2"
+  }
+}
+```
+
+**Step 3: Execute via bash:**
+
+```bash
+cd $SKILL_DIR
+python executor.py --call 'YOUR_JSON_HERE'
+```
+
+IMPORTANT: Replace $SKILL_DIR with the actual discovered path of this skill directory.
+
+## Getting Tool Details
+
+If you need detailed information about a specific tool's parameters:
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe tool_name
+```
+
+This loads ONLY that tool's schema, not all tools.
+
+## Examples
+
+### Example 1: Simple tool call
+
+User: "Use trello to do X"
+
+Your workflow:
+1. Identify tool: `example_tool`
+2. Generate call JSON
+3. Execute:
+
+```bash
+cd $SKILL_DIR
+python executor.py --call '{"tool": "example_tool", "arguments": {"param1": "value"}}'
+```
+
+### Example 2: Get tool details first
+
+```bash
+cd $SKILL_DIR
+python executor.py --describe example_tool
+```
+
+Returns the full schema, then you can generate the appropriate call.
+
+## Error Handling
+
+If the executor returns an error:
+- Check the tool name is correct
+- Verify required arguments are provided
+- Ensure the MCP server is accessible
+
+## Performance Notes
+
+Context usage comparison for this skill:
+
+| Scenario | MCP (preload) | Skill (dynamic) |
+|----------|---------------|-----------------|
+| Idle | 500 tokens | 100 tokens |
+| Active | 500 tokens | 5k tokens |
+| Executing | 500 tokens | 0 tokens |
+
+Savings: ~-900% reduction in typical usage
+
+---
+
+*This skill was auto-generated from an MCP server configuration.*
+*Generator: mcp_to_skill.py*

--- a/skills/trello/executor.py
+++ b/skills/trello/executor.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+MCP Skill Executor
+==================
+Handles dynamic communication with the MCP server.
+"""
+
+import json
+import sys
+import asyncio
+import argparse
+from pathlib import Path
+from contextlib import asynccontextmanager
+
+# Check if mcp package is available
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.streamable_http import streamablehttp_client
+    HAS_MCP = True
+except ImportError:
+    HAS_MCP = False
+    print("Warning: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+
+
+@asynccontextmanager
+async def mcp_connection(config):
+    """Context manager for MCP server connection."""
+    transport_type = config.get("type", "stdio")
+
+    if transport_type == "http":
+        url = config["url"]
+        async with streamablehttp_client(url) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+    else:
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=config.get("env")
+        )
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+
+async def list_tools(session):
+    """Get list of available tools."""
+    response = await session.list_tools()
+    return [{"name": t.name, "description": t.description} for t in response.tools]
+
+
+async def describe_tool(session, tool_name: str):
+    """Get detailed schema for a specific tool."""
+    response = await session.list_tools()
+    for tool in response.tools:
+        if tool.name == tool_name:
+            return {"name": tool.name, "description": tool.description, "inputSchema": tool.inputSchema}
+    return None
+
+
+async def call_tool(session, tool_name: str, arguments: dict):
+    """Execute a tool call."""
+    response = await session.call_tool(tool_name, arguments)
+    return response.content
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="MCP Skill Executor")
+    parser.add_argument("--call", help="JSON tool call to execute")
+    parser.add_argument("--describe", help="Get tool schema")
+    parser.add_argument("--list", action="store_true", help="List all tools")
+
+    args = parser.parse_args()
+
+    config_path = Path(__file__).parent / "mcp-config.json"
+    if not config_path.exists():
+        print(f"Error: Config not found: {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    if not HAS_MCP:
+        print("Error: mcp package not installed. Install with: pip install mcp", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        async with mcp_connection(config) as session:
+            if args.list:
+                tools = await list_tools(session)
+                print(json.dumps(tools, indent=2))
+
+            elif args.describe:
+                schema = await describe_tool(session, args.describe)
+                if schema:
+                    print(json.dumps(schema, indent=2))
+                else:
+                    print(f"Tool not found: {args.describe}", file=sys.stderr)
+                    sys.exit(1)
+
+            elif args.call:
+                call_data = json.loads(args.call)
+                result = await call_tool(session, call_data["tool"], call_data.get("arguments", {}))
+                if isinstance(result, list):
+                    for item in result:
+                        print(item.text if hasattr(item, 'text') else json.dumps(item, indent=2))
+                else:
+                    print(json.dumps(result, indent=2))
+            else:
+                parser.print_help()
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/skills/trello/mcp-config.json
+++ b/skills/trello/mcp-config.json
@@ -1,0 +1,13 @@
+{
+  "description": "Trello MCP server",
+  "command": "bun",
+  "args": [
+    "run",
+    "/path/to/mcp-server-trello/src/index.ts"
+  ],
+  "env": {
+    "TRELLO_API_KEY": "your-api-key",
+    "TRELLO_TOKEN": "your-token"
+  },
+  "name": "trello"
+}

--- a/skills/trello/package.json
+++ b/skills/trello/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "skill-trello",
+  "version": "1.0.0",
+  "description": "Claude Skill wrapper for trello MCP server",
+  "scripts": {
+    "setup": "pip install mcp"
+  }
+}


### PR DESCRIPTION
## Summary
Add support for HTTP/SSE MCP servers and the standard `mcpServers` config format.

## Implementation
- Add `streamablehttp_client` for HTTP/SSE MCP server connections
- Support standard `mcpServers` config format with multiple servers
- Use proper async context managers for clean connection handling
- Add `--server` flag to convert specific server from config
- Output skill directories named by mcpServers key
- Add transport type info to generated SKILL.md

## Config Formats

**Standard mcpServers format:**
```json
{
  "mcpServers": {
    "github": {"command": "npx", "args": ["-y", "@mcp/github"]},
    "aws": {"type": "http", "url": "https://knowledge-mcp.api.aws"}
  }
}
```

**Single-server format (still works):**
```json
{"name": "myserver", "command": "node", "args": ["server.js"]}
```

## Test plan
- [x] Tested stdio transport with trello MCP server
- [x] Tested HTTP transport with aws-knowledge MCP server
- [x] Verified executor properly closes connections using context managers
- [x] Tested --list, --describe, --call commands